### PR TITLE
Reshape public API

### DIFF
--- a/src/bitcoin_rpc_api.rs
+++ b/src/bitcoin_rpc_api.rs
@@ -1,9 +1,10 @@
 use bitcoin::Address;
 use bitcoin::Script;
-use bitcoincore::TxOutConfirmations;
 use jsonrpc_client::ClientError;
 use jsonrpc_client::RpcError;
-use types::*;
+use rpc;
+use BlockHash;
+use TransactionId;
 
 #[allow(unused_variables)]
 pub trait BitcoinRpcApi: Send + Sync {
@@ -13,7 +14,7 @@ pub trait BitcoinRpcApi: Send + Sync {
         &self,
         number_of_required_signatures: u32,
         participants: Vec<&Address>,
-    ) -> Result<Result<MultiSigAddress, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::MultiSigAddress, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -28,29 +29,32 @@ pub trait BitcoinRpcApi: Send + Sync {
 
     fn create_raw_transaction(
         &self,
-        inputs: Vec<&NewTransactionInput>,
-        output: &NewTransactionOutput,
-    ) -> Result<Result<SerializedRawTransaction, RpcError>, ClientError> {
+        inputs: Vec<&rpc::NewTransactionInput>,
+        output: &rpc::NewTransactionOutput,
+    ) -> Result<Result<rpc::SerializedRawTransaction, RpcError>, ClientError> {
         unimplemented!()
     }
 
     fn decode_rawtransaction(
         &self,
-        tx: SerializedRawTransaction,
-    ) -> Result<Result<DecodedRawTransaction, RpcError>, ClientError> {
+        tx: rpc::SerializedRawTransaction,
+    ) -> Result<Result<rpc::DecodedRawTransaction, RpcError>, ClientError> {
         unimplemented!()
     }
 
     fn decode_script(
         &self,
         script: Script,
-    ) -> Result<Result<DecodedScript, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::DecodedScript, RpcError>, ClientError> {
         unimplemented!()
     }
 
     // TODO: disconnectnode
 
-    fn dump_privkey(&self, address: &Address) -> Result<Result<PrivateKey, RpcError>, ClientError> {
+    fn dump_privkey(
+        &self,
+        address: &Address,
+    ) -> Result<Result<rpc::PrivateKey, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -61,9 +65,9 @@ pub trait BitcoinRpcApi: Send + Sync {
 
     fn fund_raw_transaction(
         &self,
-        tx: &SerializedRawTransaction,
-        options: &FundingOptions,
-    ) -> Result<Result<FundingResult, RpcError>, ClientError> {
+        tx: &rpc::SerializedRawTransaction,
+        options: &rpc::FundingOptions,
+    ) -> Result<Result<rpc::FundingResult, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -77,7 +81,10 @@ pub trait BitcoinRpcApi: Send + Sync {
     // TODO: generatetoaddress
     // TODO: getaccountaddress
 
-    fn get_account(&self, address: &Address) -> Result<Result<Account, RpcError>, ClientError> {
+    fn get_account(
+        &self,
+        address: &Address,
+    ) -> Result<Result<rpc::Account, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -92,7 +99,7 @@ pub trait BitcoinRpcApi: Send + Sync {
     fn get_block(
         &self,
         header_hash: &BlockHash,
-    ) -> Result<Result<Block<TransactionId>, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Block<TransactionId>, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -100,15 +107,15 @@ pub trait BitcoinRpcApi: Send + Sync {
     fn get_block_verbose(
         &self,
         header_hash: &BlockHash,
-    ) -> Result<Result<Block<DecodedRawTransaction>, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Block<rpc::DecodedRawTransaction>, RpcError>, ClientError> {
         unimplemented!()
     }
 
-    fn get_blockchain_info(&self) -> Result<Result<BlockchainInfo, RpcError>, ClientError> {
+    fn get_blockchain_info(&self) -> Result<Result<rpc::BlockchainInfo, RpcError>, ClientError> {
         unimplemented!()
     }
 
-    fn get_block_count(&self) -> Result<Result<BlockHeight, RpcError>, ClientError> {
+    fn get_block_count(&self) -> Result<Result<rpc::BlockHeight, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -145,14 +152,14 @@ pub trait BitcoinRpcApi: Send + Sync {
     fn get_raw_transaction_serialized(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<SerializedRawTransaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::SerializedRawTransaction, RpcError>, ClientError> {
         unimplemented!()
     }
 
     fn get_raw_transaction_verbose(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<VerboseRawTransaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::VerboseRawTransaction, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -162,7 +169,7 @@ pub trait BitcoinRpcApi: Send + Sync {
     fn get_transaction(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<Transaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Transaction, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -190,10 +197,10 @@ pub trait BitcoinRpcApi: Send + Sync {
 
     fn list_unspent(
         &self,
-        min_confirmations: TxOutConfirmations,
+        min_confirmations: rpc::TxOutConfirmations,
         max_confirmations: Option<u32>,
         recipients: Option<Vec<Address>>,
-    ) -> Result<Result<Vec<UnspentTransactionOutput>, RpcError>, ClientError> {
+    ) -> Result<Result<Vec<rpc::UnspentTransactionOutput>, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -209,7 +216,7 @@ pub trait BitcoinRpcApi: Send + Sync {
 
     fn send_raw_transaction(
         &self,
-        tx_data: SerializedRawTransaction,
+        tx_data: rpc::SerializedRawTransaction,
     ) -> Result<Result<TransactionId, RpcError>, ClientError> {
         unimplemented!()
     }
@@ -231,11 +238,11 @@ pub trait BitcoinRpcApi: Send + Sync {
 
     fn sign_raw_transaction(
         &self,
-        tx: &SerializedRawTransaction,
-        dependencies: Option<Vec<&TransactionOutputDetail>>,
-        private_keys: Option<Vec<&PrivateKey>>,
-        signature_hash_type: Option<SigHashType>,
-    ) -> Result<Result<SigningResult, RpcError>, ClientError> {
+        tx: &rpc::SerializedRawTransaction,
+        dependencies: Option<Vec<&rpc::TransactionOutputDetail>>,
+        private_keys: Option<Vec<&rpc::PrivateKey>>,
+        signature_hash_type: Option<rpc::SigHashType>,
+    ) -> Result<Result<rpc::SigningResult, RpcError>, ClientError> {
         unimplemented!()
     }
 
@@ -245,7 +252,7 @@ pub trait BitcoinRpcApi: Send + Sync {
     fn validate_address(
         &self,
         address: &Address,
-    ) -> Result<Result<AddressValidationResult, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::AddressValidationResult, RpcError>, ClientError> {
         unimplemented!()
     }
 

--- a/src/bitcoincore.rs
+++ b/src/bitcoincore.rs
@@ -5,10 +5,12 @@ use jsonrpc_client::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION},
     ClientError, HTTPClient, JsonRpcVersion, RpcClient, RpcError, RpcRequest,
 };
+use rpc;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::fmt::Debug;
-use types::*;
 use BitcoinRpcApi;
+use BlockHash;
+use TransactionId;
 
 struct RetryConfig {
     max_retries: u32,
@@ -18,11 +20,6 @@ struct RetryConfig {
 pub struct BitcoinCoreClient {
     client: RpcClient,
     retry_config: Option<RetryConfig>,
-}
-
-pub enum TxOutConfirmations {
-    Unconfirmed,
-    AtLeast(i32),
 }
 
 #[allow(dead_code)]
@@ -78,7 +75,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         &self,
         number_of_required_signatures: u32,
         participants: Vec<&Address>,
-    ) -> Result<Result<MultiSigAddress, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::MultiSigAddress, RpcError>, ClientError> {
         self.send(&RpcRequest::new2(
             JsonRpcVersion::V1,
             "42",
@@ -90,9 +87,9 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn create_raw_transaction(
         &self,
-        inputs: Vec<&NewTransactionInput>,
-        output: &NewTransactionOutput,
-    ) -> Result<Result<SerializedRawTransaction, RpcError>, ClientError> {
+        inputs: Vec<&rpc::NewTransactionInput>,
+        output: &rpc::NewTransactionOutput,
+    ) -> Result<Result<rpc::SerializedRawTransaction, RpcError>, ClientError> {
         self.send(&RpcRequest::new2(
             JsonRpcVersion::V1,
             "42",
@@ -104,8 +101,8 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn decode_rawtransaction(
         &self,
-        tx: SerializedRawTransaction,
-    ) -> Result<Result<DecodedRawTransaction, RpcError>, ClientError> {
+        tx: rpc::SerializedRawTransaction,
+    ) -> Result<Result<rpc::DecodedRawTransaction, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -117,7 +114,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
     fn decode_script(
         &self,
         script: Script,
-    ) -> Result<Result<DecodedScript, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::DecodedScript, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -126,7 +123,10 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         ))
     }
 
-    fn dump_privkey(&self, address: &Address) -> Result<Result<PrivateKey, RpcError>, ClientError> {
+    fn dump_privkey(
+        &self,
+        address: &Address,
+    ) -> Result<Result<rpc::PrivateKey, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -137,9 +137,9 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn fund_raw_transaction(
         &self,
-        tx: &SerializedRawTransaction,
-        options: &FundingOptions,
-    ) -> Result<Result<FundingResult, RpcError>, ClientError> {
+        tx: &rpc::SerializedRawTransaction,
+        options: &rpc::FundingOptions,
+    ) -> Result<Result<rpc::FundingResult, RpcError>, ClientError> {
         self.send(&RpcRequest::new2(
             JsonRpcVersion::V1,
             "42",
@@ -161,7 +161,10 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         ))
     }
 
-    fn get_account(&self, address: &Address) -> Result<Result<Account, RpcError>, ClientError> {
+    fn get_account(
+        &self,
+        address: &Address,
+    ) -> Result<Result<rpc::Account, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -181,7 +184,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
     fn get_block(
         &self,
         header_hash: &BlockHash,
-    ) -> Result<Result<Block<TransactionId>, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Block<TransactionId>, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -193,7 +196,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
     fn get_block_verbose(
         &self,
         header_hash: &BlockHash,
-    ) -> Result<Result<Block<DecodedRawTransaction>, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Block<rpc::DecodedRawTransaction>, RpcError>, ClientError> {
         self.send(&RpcRequest::new2(
             JsonRpcVersion::V1,
             "42",
@@ -203,7 +206,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         ))
     }
 
-    fn get_blockchain_info(&self) -> Result<Result<BlockchainInfo, RpcError>, ClientError> {
+    fn get_blockchain_info(&self) -> Result<Result<rpc::BlockchainInfo, RpcError>, ClientError> {
         self.send(&RpcRequest::new0(
             JsonRpcVersion::V1,
             "42",
@@ -211,7 +214,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
         ))
     }
 
-    fn get_block_count(&self) -> Result<Result<BlockHeight, RpcError>, ClientError> {
+    fn get_block_count(&self) -> Result<Result<rpc::BlockHeight, RpcError>, ClientError> {
         self.send(&RpcRequest::new0(JsonRpcVersion::V1, "42", "getblockcount"))
     }
 
@@ -237,21 +240,21 @@ impl BitcoinRpcApi for BitcoinCoreClient {
     fn get_raw_transaction_serialized(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<SerializedRawTransaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::SerializedRawTransaction, RpcError>, ClientError> {
         self.get_raw_transaction(tx, false)
     }
 
     fn get_raw_transaction_verbose(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<VerboseRawTransaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::VerboseRawTransaction, RpcError>, ClientError> {
         self.get_raw_transaction(tx, true)
     }
 
     fn get_transaction(
         &self,
         tx: &TransactionId,
-    ) -> Result<Result<Transaction, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::Transaction, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",
@@ -262,13 +265,15 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn list_unspent(
         &self,
-        min_confirmations: TxOutConfirmations,
+        min_confirmations: rpc::TxOutConfirmations,
         max_confirmations: Option<u32>,
         recipients: Option<Vec<Address>>,
-    ) -> Result<Result<Vec<UnspentTransactionOutput>, RpcError>, ClientError> {
+    ) -> Result<Result<Vec<rpc::UnspentTransactionOutput>, RpcError>, ClientError> {
+        use rpc::TxOutConfirmations::*;
+
         let min_confirmations = match min_confirmations {
-            TxOutConfirmations::Unconfirmed => 0,
-            TxOutConfirmations::AtLeast(number) => number,
+            Unconfirmed => 0,
+            AtLeast(number) => number,
         };
 
         self.send(&RpcRequest::new3(
@@ -283,7 +288,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn send_raw_transaction(
         &self,
-        tx_data: SerializedRawTransaction,
+        tx_data: rpc::SerializedRawTransaction,
     ) -> Result<Result<TransactionId, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
@@ -309,11 +314,11 @@ impl BitcoinRpcApi for BitcoinCoreClient {
 
     fn sign_raw_transaction(
         &self,
-        tx: &SerializedRawTransaction,
-        dependencies: Option<Vec<&TransactionOutputDetail>>,
-        private_keys: Option<Vec<&PrivateKey>>,
-        signature_hash_type: Option<SigHashType>,
-    ) -> Result<Result<SigningResult, RpcError>, ClientError> {
+        tx: &rpc::SerializedRawTransaction,
+        dependencies: Option<Vec<&rpc::TransactionOutputDetail>>,
+        private_keys: Option<Vec<&rpc::PrivateKey>>,
+        signature_hash_type: Option<rpc::SigHashType>,
+    ) -> Result<Result<rpc::SigningResult, RpcError>, ClientError> {
         self.send(&RpcRequest::new4(
             JsonRpcVersion::V1,
             "42",
@@ -328,7 +333,7 @@ impl BitcoinRpcApi for BitcoinCoreClient {
     fn validate_address(
         &self,
         address: &Address,
-    ) -> Result<Result<AddressValidationResult, RpcError>, ClientError> {
+    ) -> Result<Result<rpc::AddressValidationResult, RpcError>, ClientError> {
         self.send(&RpcRequest::new1(
             JsonRpcVersion::V1,
             "42",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,32 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
-pub use bitcoin_rpc_api::*;
-pub use bitcoincore::*;
-pub use jsonrpc_client::{ClientError, RpcError};
-pub use stub_rpc_client::*;
-pub use types::*;
-
 mod bitcoin_rpc_api;
 mod bitcoincore;
 mod stub_rpc_client;
 mod types;
+
+// Re-export types from rust-bitcoin so explicit dependency is not necessarily needed
+pub type TransactionId = bitcoin::util::hash::Sha256dHash;
+pub type BlockHash = bitcoin::util::hash::Sha256dHash;
+
+pub use bitcoin::network::constants::Network;
+pub use bitcoin::util::privkey::Privkey;
+pub use bitcoin::Address;
+pub use bitcoin::Script;
+
+pub use bitcoin_rpc_api::BitcoinRpcApi;
+pub use bitcoincore::BitcoinCoreClient;
+pub use stub_rpc_client::BitcoinStubClient;
+
+pub use jsonrpc_client::{ClientError, RpcError};
+
+pub mod rpc {
+    pub use types::address::*;
+    pub use types::block::*;
+    pub use types::blockchain::*;
+    pub use types::keys::*;
+    pub use types::script::*;
+    pub use types::transaction::*;
+    pub use types::{Account, SigHashType, TxOutConfirmations};
+}

--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -1,6 +1,6 @@
 use bitcoin::Address;
 use bitcoin::Script;
-use types::ScriptType;
+use types::script::ScriptType;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
 pub struct MultiSigAddress {

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -1,6 +1,4 @@
-use bitcoin::util::hash::Sha256dHash;
-
-pub type BlockHash = Sha256dHash;
+use BlockHash;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct BlockHeight(u32);
@@ -48,7 +46,7 @@ pub struct Block<T> {
 mod tests {
     use super::*;
     use serde_json;
-    use types::TransactionId;
+    use TransactionId;
 
     #[test]
     fn can_deserialize_block_struct() {

--- a/src/types/blockchain.rs
+++ b/src/types/blockchain.rs
@@ -1,5 +1,4 @@
 use bitcoin::network::constants::Network;
-use types::*;
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct SoftFork {
@@ -41,7 +40,7 @@ pub struct Bip9SoftForkDetails {
 
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct BlockchainInfo {
-    #[serde(with = "self::serde::network")]
+    #[serde(with = "super::serde::network")]
     pub chain: Network,
     pub blocks: u64,
     pub headers: u64,

--- a/src/types/from_str.rs
+++ b/src/types/from_str.rs
@@ -1,9 +1,0 @@
-macro_rules! from_str {
-    ($name:tt) => {
-        impl<'a> From<&'a str> for $name {
-            fn from(string: &str) -> Self {
-                $name(string.to_string())
-            }
-        }
-    };
-}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,25 +1,11 @@
-#[macro_use]
-mod from_str;
-mod address;
-mod block;
-mod blockchain;
-mod keys;
-mod script;
 mod serde;
-mod transaction;
 
-pub use self::{address::*, block::*, blockchain::*, keys::*, script::*, transaction::*};
-
-use bitcoin::util::hash::Sha256dHash;
-
-// Re-export types from rust-bitcoin so explicit dependency is not necessarily needed
-pub type TransactionId = Sha256dHash;
-pub type BlockHash = Sha256dHash;
-
-pub use bitcoin::network::constants::Network;
-pub use bitcoin::util::privkey::Privkey;
-pub use bitcoin::Address;
-pub use bitcoin::Script;
+pub mod address;
+pub mod block;
+pub mod blockchain;
+pub mod keys;
+pub mod script;
+pub mod transaction;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Account(pub String);
@@ -40,4 +26,9 @@ pub enum SigHashType {
     None_AnyoneCanPay,
     #[serde(rename = "SINGLE|ANYONECANPAY")]
     Single_AnyoneCanPay,
+}
+
+pub enum TxOutConfirmations {
+    Unconfirmed,
+    AtLeast(i32),
 }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -7,8 +7,8 @@ use bitcoin::{
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::HashMap, fmt, str::FromStr};
 use types::script::ScriptPubKey;
-use types::BlockHash;
-use types::TransactionId;
+use BlockHash;
+use TransactionId;
 
 #[derive(Debug, PartialEq, Clone)]
 //TODO: can be used once https://github.com/rust-bitcoin/rust-bitcoin/issues/104 is fixed
@@ -77,9 +77,7 @@ impl FromStr for TransactionWrapper {
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
-pub struct SerializedRawTransaction(String);
-
-from_str!(SerializedRawTransaction);
+pub struct SerializedRawTransaction(pub String);
 
 impl From<SerializedRawTransaction> for BitcoinTransaction {
     fn from(serialized_tx: SerializedRawTransaction) -> Self {
@@ -400,9 +398,7 @@ mod tests {
     use serde_json;
     use std::collections::HashMap;
     use std_hex;
-    use types::script::ScriptPubKey;
     use types::script::ScriptType;
-    use types::BlockHash;
 
     #[test]
     fn should_deserialize_transaction() {
@@ -495,8 +491,8 @@ mod tests {
 
         let tx: SerializedRawTransaction = serde_json::from_str(json).unwrap();
 
-        assert_eq!(tx, SerializedRawTransaction::from(
-            "0200000000010144af9381cd3cb3d14d549b27c8d8a4c87d1d58e501df656342363886277f62e10000000000feffffff02aba9ac0300000000160014908abcc05defb6ba5630268b395b1fab19ad50d760566c0000000000220020c39353c0df01296ab055e83b701715b765636cf91c795deb7573e4b055ada53302473044022010d3b0f0e48977b5c7af7f6a0839a8ed24cd760c4e95668ed7b3275fca727360022007a27825d82a1e69bff2e8cbf195aa4280c214f1cf7650afb6fa2eb49a9765040121036bc4598b0de6ac9c560f1322ce86a0bf27e934837ac86196337db06002c3a352f83a1400"));
+        assert_eq!(tx, SerializedRawTransaction(String::from("0200000000010144af9381cd3cb3d14d549b27c8d8a4c87d1d58e501df656342363886277f62e10000000000feffffff02aba9ac0300000000160014908abcc05defb6ba5630268b395b1fab19ad50d760566c0000000000220020c39353c0df01296ab055e83b701715b765636cf91c795deb7573e4b055ada53302473044022010d3b0f0e48977b5c7af7f6a0839a8ed24cd760c4e95668ed7b3275fca727360022007a27825d82a1e69bff2e8cbf195aa4280c214f1cf7650afb6fa2eb49a9765040121036bc4598b0de6ac9c560f1322ce86a0bf27e934837ac86196337db06002c3a352f83a1400")
+            ));
         let bitcoin_tx: BitcoinTransaction = tx.into();
         let expected_txid = TransactionId::from_hex(
             "85a42342de714d4fa39af1fa503b9363df8a31450ff22869b300f686737370e4",
@@ -596,7 +592,7 @@ mod tests {
                     },
                 }
             ],
-            hex: SerializedRawTransaction::from("020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0603142d010101ffffffff0200000000000000002321039b0e80cdda15ac2164392dfaf4f3eb36dd914dcb1c405eec3dd8c9ebf6c13fc1ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000"),
+            hex: SerializedRawTransaction(String::from("020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0603142d010101ffffffff0200000000000000002321039b0e80cdda15ac2164392dfaf4f3eb36dd914dcb1c405eec3dd8c9ebf6c13fc1ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000")),
             blockhash: BlockHash::from_hex("796d7a2dbb1213b65dc2f7170575755efdfae8340b2183e971ed5a89113bbedf").unwrap(),
             confirmations: 9,
             time: 1525393130,

--- a/tests/common/test_client.rs
+++ b/tests/common/test_client.rs
@@ -10,12 +10,12 @@ impl<'a> BitcoinCoreTestClient<'a> {
         BitcoinCoreTestClient { client }
     }
 
-    pub fn a_utxo(&self) -> UnspentTransactionOutput {
+    pub fn a_utxo(&self) -> rpc::UnspentTransactionOutput {
         let _ = self.a_block(); // Need to generate a block first
 
         let mut utxos = self
             .client
-            .list_unspent(TxOutConfirmations::AtLeast(6), None, None)
+            .list_unspent(rpc::TxOutConfirmations::AtLeast(6), None, None)
             .unwrap()
             .unwrap();
 
@@ -36,7 +36,7 @@ impl<'a> BitcoinCoreTestClient<'a> {
         self.client.get_new_address().unwrap().unwrap()
     }
 
-    pub fn a_block(&self) -> Block<TransactionId> {
+    pub fn a_block(&self) -> rpc::Block<TransactionId> {
         self.client
             .generate(101)
             .and_then(|response| {

--- a/tests/rpc_calls.rs
+++ b/tests/rpc_calls.rs
@@ -68,7 +68,7 @@ fn listunspent() {
     setup();
     assert_successful_result(|client| {
         let _ = client.generate(101);
-        client.list_unspent(TxOutConfirmations::Unconfirmed, Some(101), None)
+        client.list_unspent(rpc::TxOutConfirmations::Unconfirmed, Some(101), None)
     })
 }
 
@@ -182,7 +182,7 @@ fn decode_rawtransaction() {
     setup();
 
     assert_successful_result(|client| {
-        client.decode_rawtransaction(SerializedRawTransaction::from("0100000001bafe2175b9d7b3041ebac529056b393cf2997f7964485aa382ffa449ffdac02a000000008a473044022013d212c22f0b46bb33106d148493b9a9723adb2c3dd3a3ebe3a9c9e3b95d8cb00220461661710202fbab550f973068af45c294667fc4dc526627a7463eb23ab39e9b01410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ffffffff01b0a86a00000000001976a91401b81d5fa1e55e069e3cc2db9c19e2e80358f30688ac00000000"))
+        client.decode_rawtransaction(rpc::SerializedRawTransaction("0100000001bafe2175b9d7b3041ebac529056b393cf2997f7964485aa382ffa449ffdac02a000000008a473044022013d212c22f0b46bb33106d148493b9a9723adb2c3dd3a3ebe3a9c9e3b95d8cb00220461661710202fbab550f973068af45c294667fc4dc526627a7463eb23ab39e9b01410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ffffffff01b0a86a00000000001976a91401b81d5fa1e55e069e3cc2db9c19e2e80358f30688ac00000000".into()))
     })
 }
 
@@ -198,7 +198,7 @@ fn create_raw_transaction() {
 
         let utxo = test_client.a_utxo();
 
-        let input = NewTransactionInput::from_utxo(&utxo);
+        let input = rpc::NewTransactionInput::from_utxo(&utxo);
         let mut map = HashMap::new();
         map.insert(alice, utxo.amount);
 
@@ -232,7 +232,7 @@ fn sign_raw_transaction() {
 
         let utxo = test_client.a_utxo();
 
-        let input = NewTransactionInput::from_utxo(&utxo);
+        let input = rpc::NewTransactionInput::from_utxo(&utxo);
         let mut map = HashMap::new();
         map.insert(alice, utxo.amount);
 
@@ -246,7 +246,7 @@ fn sign_raw_transaction() {
             &tx,
             None,
             Some(vec![&alice_private_key]),
-            Some(SigHashType::Single_AnyoneCanPay),
+            Some(rpc::SigHashType::Single_AnyoneCanPay),
         )
     })
 }
@@ -283,7 +283,7 @@ fn fund_raw_transaction() {
             .create_raw_transaction(Vec::new(), &outputs)
             .unwrap()
             .unwrap();
-        let options = FundingOptions::new();
+        let options = rpc::FundingOptions::new();
 
         client.fund_raw_transaction(&raw_tx, &options)
     })


### PR DESCRIPTION
We expose our own types under the `rpc` module and everything else in
the root module. This allows for convenient import of everything through
`bitcoin_rpc_client::*`.